### PR TITLE
rename script `typeCheck` to `checkTypes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2019-02-10
+
+- rename script `typeCheck` to `checkTypes`
+
 # 2019-02-06
 
 - add `prebuild` & `release` scripts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 2019-02-10
 
+- add `"README.md"` and `"CHANGELOG.md"` to the list of included files in
+  package.json
 - rename script `typeCheck` to `checkTypes`
 
 # 2019-02-06

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ yarn start
 
 ```bash
 $ yarn prebuild
-# run `clean`, `fix`, `lint` & `typeCheck`
+# run `clean`, `fix`, `lint` & `checkTypes`
 
 $ yarn build
 # compile all the `src/` folder and place the output in the `dist/` folder. It
@@ -58,7 +58,7 @@ $ yarn release
 $ yarn test
 # run all the test files using JEST
 
-$ yarn typeCheck
+$ yarn checkTypes
 # check for typescript errors
 
 $ yarn build:types
@@ -88,7 +88,7 @@ Check `package.json` files in the `"scripts"` field for more details.
 
 ## Git Hooks
 
-Includes a _pre-commit_ hook that runs `fix`, `lint` and `typeCheck` in your
+Includes a _pre-commit_ hook that runs `fix`, `lint` and `checkTypes` in your
 **staged files** to check for errors (auto fix them when possible) and check for
 typescript errors before commits. It will **abort** the commit phase if errors
 prevails after the auto fixing. It uses [husky] and [lint-staged] for that.

--- a/package.json
+++ b/package.json
@@ -78,6 +78,8 @@
     ]
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "CHANGELOG.md"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
     "watch": "yarn build --watch",
     "test": "jest",
     "build": "yarn build:types && babel src --out-dir dist --extensions '.ts,.js' --source-maps inline --ignore 'src/**/*.spec.js,src/**/*.test.js'",
-    "prebuild": "yarn clean && yarn fix && yarn lint && yarn typeCheck",
+    "prebuild": "yarn clean && yarn fix && yarn lint && yarn checkTypes",
     "release": "yarn prebuild && yarn build",
     "build:types": "tsc --emitDeclarationOnly --declaration --allowJs false --checkJs false --noEmit false",
     "watch:types": "yarn build:types --watch",
-    "typeCheck": "tsc",
+    "checkTypes": "tsc",
     "checkTslint": "tslint-config-prettier-check ./tslint.json",
     "checkEslint": "eslint --print-config . | eslint-config-prettier-check",
     "fix": "concurrently \"yarn fix-ts\" \"yarn fix-js\"",
@@ -70,7 +70,7 @@
     "*.{ts}": [
       "yarn fix-ts",
       "yarn lint-ts",
-      "yarn typeCheck"
+      "yarn checkTypes"
     ],
     "*.{js}": [
       "yarn fix-js",


### PR DESCRIPTION
- add `"README.md"` and `"CHANGELOG.md"` to the list of included files in
  package.json
- rename script `typeCheck` to `checkTypes`